### PR TITLE
Fix sorting

### DIFF
--- a/SortInventory/SortInventory.csproj
+++ b/SortInventory/SortInventory.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -8,8 +8,9 @@
     <OutputType>Library</OutputType>
     <RootNamespace>SortInventory</RootNamespace>
     <AssemblyName>SortInventory</AssemblyName>
-    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -20,6 +21,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -29,6 +31,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <AppDesigner Include="Properties\" />
@@ -38,36 +41,52 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>E:\SteamLibrary\steamapps\common\Raft\Raft_Data/Managed/Assembly-CSharp.dll</HintPath>
-      <HintPath Condition="Exists('C:\Program Files (x86)\Steam\steamapps\common\Raft')">C:\Program Files (x86)\Steam\steamapps\common\Raft\Raft_Data\Managed\Assembly-CSharp.dll</HintPath>
+    <Reference Include="0Harmony">
+      <HintPath>..\..\..\..\AppData\Roaming\RaftModLoader\binaries\0Harmony.dll</HintPath>
     </Reference>
-    <Reference Include="AssemblyLoader, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath Condition="Exists('..\..\..\..\AppData\Roaming\RaftModLoader')">..\..\..\..\AppData\Roaming\RaftModLoader\binaries\HMLCoreLibrary.dll</HintPath>
+    <Reference Include="Assembly-CSharp">
+      <HintPath>E:\SteamLibrary\steamapps\common\Raft\Raft_Data\Managed\Assembly-CSharp.dll</HintPath>
     </Reference>
-    <Reference Include="coremod, Version=0.0.0.1, Culture=neutral, PublicKeyToken=null">
-      <HintPath>E:\SteamLibrary\steamapps\common\Raft\RaftModLoader/coremod.dll</HintPath>
-      <HintPath Condition="Exists('..\..\..\..\AppData\Roaming\RaftModLoader')">..\..\..\..\AppData\Roaming\RaftModLoader\binaries\coremod.dll</HintPath>
+    <Reference Include="Assembly-CSharp-firstpass">
+      <HintPath>E:\SteamLibrary\steamapps\common\Raft\Raft_Data\Managed\Assembly-CSharp-firstpass.dll</HintPath>
+    </Reference>
+    <Reference Include="coremod">
+      <HintPath>..\..\..\..\AppData\Roaming\RaftModLoader\binaries\coremod.dll</HintPath>
+    </Reference>
+    <Reference Include="HMLCoreLibrary">
+      <HintPath>..\..\..\..\AppData\Roaming\RaftModLoader\binaries\HMLCoreLibrary.dll</HintPath>
+    </Reference>
+    <Reference Include="SharpZipLib">
+      <HintPath>..\..\..\..\AppData\Roaming\RaftModLoader\binaries\SharpZipLib.dll</HintPath>
+    </Reference>
+    <Reference Include="System.ValueTuple">
+      <HintPath>..\..\..\..\AppData\Roaming\RaftModLoader\binaries\System.ValueTuple.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.CoreModule">
       <HintPath>E:\SteamLibrary\steamapps\common\Raft\Raft_Data/Managed/UnityEngine.CoreModule.dll</HintPath>
       <HintPath Condition="Exists('C:\Program Files (x86)\Steam\steamapps\common\Raft')">C:\Program Files (x86)\Steam\steamapps\common\Raft\Raft_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
     </Reference>
-    <Reference Include="Assembly-CSharp-firstpass">
-      <HintPath>E:\SteamLibrary\steamapps\common\Raft\Raft_Data/Managed/Assembly-CSharp.dllFIRST</HintPath>
-      <HintPath Condition="Exists('C:\Program Files (x86)\Steam\steamapps\common\Raft')">C:\Program Files (x86)\Steam\steamapps\common\Raft\Raft_Data\Managed\Assembly-CSharp-firstpass.dll</HintPath>
-    </Reference>
     <Reference Include="UnityEngine">
       <HintPath>E:\SteamLibrary\steamapps\common\Raft\Raft_Data/Managed/UnityEngine.dll</HintPath>
       <HintPath Condition="Exists('C:\Program Files (x86)\Steam\steamapps\common\Raft')">C:\Program Files (x86)\Steam\steamapps\common\Raft\Raft_Data\Managed\UnityEngine.dll</HintPath>
     </Reference>
-    <Reference Include="UnityEngine.UI">
-      <HintPath>E:\SteamLibrary\steamapps\common\Raft\Raft_Data/Managed/UnityEngine.dll_UI</HintPath>
-      <HintPath Condition="Exists('C:\Program Files (x86)\Steam\steamapps\common\Raft')">C:\Program Files (x86)\Steam\steamapps\common\Raft\Raft_Data\Managed\UnityEngine.UI.dll</HintPath>
+    <Reference Include="UnityEngine.InputLegacyModule">
+      <HintPath>E:\SteamLibrary\steamapps\common\Raft\Raft_Data\Managed\UnityEngine.InputLegacyModule.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine.InputModule">
+      <HintPath>E:\SteamLibrary\steamapps\common\Raft\Raft_Data\Managed\UnityEngine.InputModule.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
     <Content Include="modinfo.json" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+    <PostBuildEvent>call cd $(SolutionDir)
+start build.bat
+echo 🔰 =============== 🔰 MOD BUILD SCRIPT 🔰 =============== 🔰
+echo ✔️ Mod successfully built as $(SolutionDir)$(ProjectName).rmod ✔️
+echo ===========================================================
+</PostBuildEvent>
+  </PropertyGroup>
 </Project>

--- a/SortInventory/SortInventoryMod.cs
+++ b/SortInventory/SortInventoryMod.cs
@@ -68,7 +68,7 @@ namespace SortInventory
                 Slot currSlot = nonHotbar[i];
                 if (!currSlot.IsEmpty)
                 {
-                    Slot toSlot = this.FindSuitableSlot(nonHotbar, currSlot.GetItemBase());
+                    Slot toSlot = this.FindSuitableSlot(nonHotbar, i, currSlot.GetItemBase());
                     if (toSlot != currSlot && toSlot != null)
                     {
                         this.TransferItems(toSlot, currSlot);
@@ -100,11 +100,12 @@ namespace SortInventory
             }
         }
 
-        private Slot FindSuitableSlot(List<Slot> inv, Item_Base stackableItem = null)
+        private Slot FindSuitableSlot(List<Slot> inv, int currIndex, Item_Base stackableItem = null)
         {
             bool flag = stackableItem != null && stackableItem.settings_Inventory.Stackable;
-            foreach (Slot slot2 in inv)
+            for (var i = 0; i < currIndex; i++)
             {
+                Slot slot2 = inv[i];
                 if (slot2.IsEmpty)
                 {
                     return slot2;

--- a/SortInventory/SortInventoryMod.cs
+++ b/SortInventory/SortInventoryMod.cs
@@ -50,8 +50,8 @@ namespace SortInventory
                 // Reset the slot.
                 slot.Reset();
             }
-
-            tempInstances.Sort((x, y) => String.Compare(x.UniqueName, y.UniqueName, StringComparison.Ordinal));
+            
+            tempInstances.Sort((x, y) => String.Compare(x.settings_Inventory.DisplayName, y.settings_Inventory.DisplayName, StringComparison.Ordinal));
 
             // Do some assignments to sort it in the inventory
             var i = 0;

--- a/SortInventory/modinfo.json
+++ b/SortInventory/modinfo.json
@@ -2,11 +2,11 @@
   "name": "SortInventory",
   "author": "wazupwiop and traxam",
   "description": "A mod that will use a hotkey to sort inventory.",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "license": "MIT",
   "icon": "icon.png",
   "banner": "banner.png",
-  "gameVersion": "Update 11 (4677160)",
+  "gameVersion": "Update 12.01 (5720064)",
   "updateUrl": "https://www.raftmodding.com/api/v1/mods/sortinventory/version.txt",
   "isModPermanent": false,
   "excludedFiles": []

--- a/build.bat
+++ b/build.bat
@@ -4,17 +4,14 @@
 @echo off
 :: Defining the window title
 title RML Mod Build Script
-:: Retrieving the current folder name
-for %%* in (.) do set foldername=%%~n*
 :: Creating a folder to contain temporary files for the build
 mkdir "build"
 :: Copying the solution directory in the "build" folder except ".csproj, .rmod" files and "bin, obj" folders.
-robocopy "%foldername%" "build" /E /XF *.csproj *.rmod /XD bin obj
+robocopy "SortInventory" "build" /E /XF *.csproj *.rmod /XD bin obj
 :: Checking if a .rmod with the same name already exists and if it does, delete it.
-if exist "%foldername%.rmod" ( del "%foldername%.rmod" )
+if exist "SortInventory.rmod" ( del "SortInventory.rmod" )
 :: Zipping the "build" folder. (.rmod are just zipped files)
-powershell "[System.Reflection.Assembly]::LoadWithPartialName('System.IO.Compression.FileSystem');[System.IO.Compression.ZipFile]::CreateFromDirectory(\"build\", \"%foldername%.rmod\", 0, 0)"
+powershell "[System.Reflection.Assembly]::LoadWithPartialName('System.IO.Compression.FileSystem');[System.IO.Compression.ZipFile]::CreateFromDirectory(\"build\", \"SortInventory.rmod\", 0, 0)"
 :: Deleting the "build" folder
 rmdir /s /q "build"
 :: Build succeeded!
-EXIT

--- a/build.bat
+++ b/build.bat
@@ -4,14 +4,17 @@
 @echo off
 :: Defining the window title
 title RML Mod Build Script
+:: Retrieving the current folder name
+for %%* in (.) do set foldername=%%~n*
 :: Creating a folder to contain temporary files for the build
 mkdir "build"
 :: Copying the solution directory in the "build" folder except ".csproj, .rmod" files and "bin, obj" folders.
-robocopy "SortInventory" "build" /E /XF *.csproj *.rmod /XD bin obj
+robocopy "%foldername%" "build" /E /XF *.csproj *.rmod /XD bin obj
 :: Checking if a .rmod with the same name already exists and if it does, delete it.
-if exist "SortInventory.rmod" ( del "SortInventory.rmod" )
+if exist "%foldername%.rmod" ( del "%foldername%.rmod" )
 :: Zipping the "build" folder. (.rmod are just zipped files)
-powershell "[System.Reflection.Assembly]::LoadWithPartialName('System.IO.Compression.FileSystem');[System.IO.Compression.ZipFile]::CreateFromDirectory(\"build\", \"SortInventory.rmod\", 0, 0)"
+powershell "[System.Reflection.Assembly]::LoadWithPartialName('System.IO.Compression.FileSystem');[System.IO.Compression.ZipFile]::CreateFromDirectory(\"build\", \"%foldername%.rmod\", 0, 0)"
 :: Deleting the "build" folder
 rmdir /s /q "build"
 :: Build succeeded!
+EXIT


### PR DESCRIPTION
Fixes #5  by ensuring items are never moved forward of their current position when compacting.
Fixes #4  by using the localized name when sorting.

This also updates references to the current game and mod loader version, and replaces the build bat with the current one.
